### PR TITLE
Add parameter for setting failure threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Disables assertions based on violations and only logs violations to the console 
 
 Reference : https://github.com/avanslaars/cypress-axe/issues/17
 
+###### failureThreshold (optional, defaults to 0)
+
+Allows you to configure the number of violations that will cause the assertion to fail. This should be used as a temporary measure while you address accessibility violations, but can help validate that you're not regressing as you progress towards 0 violations. 
+
 ### Examples
 
 #### Basic usage

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ const checkA11y = (
   context,
   options,
   violationCallback,
-  skipFailures = false
+  skipFailures = false,
+  failureThreshold = 0
 ) => {
   cy.window({ log: false })
     .then(win => {
@@ -61,9 +62,9 @@ const checkA11y = (
     })
     .then(violations => {
       if (!skipFailures) {
-        assert.equal(
+        assert.isAtMost(
           violations.length,
-          0,
+          failureThreshold,
           `${violations.length} accessibility violation${
             violations.length === 1 ? '' : 's'
           } ${violations.length === 1 ? 'was' : 'were'} detected`


### PR DESCRIPTION
I need to be able to set some sort of threshold for a # of violations that are allowed.
I tried to get this working by setting `skipFailures = true`, and using the `violationsCallback` to run my own assertions, but running assertions in that callback makes the tests behave weirdly.

I have currently forked this repo so I can add this parameter, but I would love if it got included here so I could keep using this repo instead!