### PR TITLE
update to 3.5 axe-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-axe",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1305,9 +1305,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.4.1.tgz",
-      "integrity": "sha512-+EhIdwR0hF6aeMx46gFDUy6qyCfsL0DmBrV3Z+LxYbsOd8e1zBaPHa3f9Rbjsz2dEwSBkLw6TwML/CAIIAqRpw==",
+      "version": "3.5.5",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/axe-core/-/axe-core-3.5.5.tgz",
+      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
       "dev": true
     },
     "babel-plugin-dynamic-import-node": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-axe",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "files": [
     "dist"
   ],
@@ -29,7 +29,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "axe-core": "^3.4.1",
+    "axe-core": "^3.5.5",
     "parcel-bundler": "^1.12.4"
   },
   "dependencies": {},


### PR DESCRIPTION
This pull requests updates axe-core to 3.5. 
As mentioned here: https://github.com/avanslaars/cypress-axe/issues/36
axe-core 3.5 has some improved checks (3.4 misses things).

I have tested this manually and the change works seamlessly in my testing. Other than the fact that axe-core 3.5 checks for more accessibility violations, I wouldn't expect any regressions.

Let me know if I can add more information! Thanks.