### PR TITLE
Export the Options interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ declare global {
 	}
 }
 
-interface Options extends axe.RunOptions {
+export interface Options extends axe.RunOptions {
 	includedImpacts?: string[];
 }
 


### PR DESCRIPTION
Export the Options interface so developers can define a constant of type Options.

i.e.
```
const A11Y_OPTIONS: Options = {
    runOnly: {
      type: 'tags',
      values: ['wcag2a', 'wcag2aa'],
    },
  };```