### PR TITLE
docs: Typo on skipFailures example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ it('Has no a11y violations after button click', () => {
 
 it('Only logs a11y violations while allowing the test to pass', () => {
   // Do not fail the test when there are accessibility failures
-  cy.checkA11y(null, null, null, {skipFailures: true});
+  cy.checkA11y(null, null, null, true);
 })
 
 


### PR DESCRIPTION
The skipFailures parameter is a boolean and not an object. [Line 53](https://github.com/component-driven/cypress-axe/blob/69e1218b24a446574e33d52713c1e56e16aa6038/src/index.ts).