### PR TITLE
change require format so it is always attempted, which won't confuse …

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,12 @@ export interface Options extends axe.RunOptions {
 }
 
 export const injectAxe = () => {
-	const fileName =
-		typeof require?.resolve === 'function'
-			? require.resolve('axe-core/axe.min.js')
-			: 'node_modules/axe-core/axe.min.js';
+	let fileName;
+	try {
+		fileName = require.resolve('axe-core/axe.min.js');
+	} catch {
+		fileName = 'node_modules/axe-core/axe.min.js';
+	}
 	cy.readFile<string>(fileName).then((source) =>
 		cy.window({ log: false }).then((window) => {
 			window.eval(source);


### PR DESCRIPTION
Webpack 5 throws `Critical dependency: require function is used in a way in which dependencies cannot be statically extracted` when used with cypress-axe. This PR changes the flow so that require is always attempted within a try/catch as opposed to a conditional, which doesn't upset webpack.

I don't understand why there would ever be a situation where require doesn't exist, but this should still work in that case.

fixes #106 