### PR TITLE
Add severity levels to fail on 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Allows you to define a callback that receives the violations for custom side-eff
 
 **NOTE:** _This respects the `includedImpacts` filter and will only execute with violations that are included._
 
-##### skipFailures (optional, defaults to false)
+##### failOn (optional, defaults to 'any')
 
-Disables assertions based on violations and only logs violations to the console output. This enabled you to see violations while allowing your tests to pass. This should be used as a temporary measure while you address accessibility violations.
+Set a level to fail on. Options are 'any', 'none' or an array of levels ['minor', 'moderate', 'serious', 'critical'];
 
-Reference : https://github.com/component-driven/cypress-axe/issues/17
+Allows you to set the level of severity to fail on. If set to 'any', any level of violation will fail, whilst 'none' will allow all violations to pass. You can fine tune this with a severity array, e.g. `['serious', 'critical']` will only fail on errors at the serious or critical level. This allows you to log all violations using e.g. `cy.checkA11y(null, null, terminalLog)` whilst only failing for a particular severity level.
 
 ### Examples
 
@@ -175,7 +175,12 @@ it('Has no a11y violations after button click', () => {
 
 it('Only logs a11y violations while allowing the test to pass', () => {
   // Do not fail the test when there are accessibility failures
-  cy.checkA11y(null, null, null, true)
+  cy.checkA11y(null, null, null, 'none')
+})
+
+it('Only logs a11y violations of level "critical"', () => {
+  // Do not fail the test when there are accessibility failures below the 'critical' level
+  cy.checkA11y(null, null, ['critical'])
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,76 +1,76 @@
 {
-  "name": "cypress-axe",
-  "version": "0.8.1",
-  "license": "MIT",
-  "description": "Test accessibility with axe-core in Cypress",
-  "homepage": "https://github.com/component-driven/cypress-axe",
-  "repository": "component-driven/cypress-axe",
-  "files": [
-    "dist"
-  ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc",
-    "lint": "eslint . --cache --fix",
-    "pretest": "npm run lint",
-    "test": "npm run test:e2e:ci",
-    "posttest": "npm run format",
-    "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-    "prepublishOnly": "npm run build",
-    "start": "http-server test",
-    "cypress": "cypress open",
-    "cypress:headless": "cypress run --browser chrome --headless",
-    "test:e2e": "start-server-and-test start 8080 cypress",
-    "test:e2e:ci": "start-server-and-test start 8080 cypress:headless"
-  },
-  "engines": {
-    "node": ">=10"
-  },
-  "dependencies": {},
-  "peerDependencies": {
-    "axe-core": "^3 || ^4",
-    "cypress": "^10" 
-  },
-  "devDependencies": {
-    "@types/node": "^14.14.8",
-    "@typescript-eslint/eslint-plugin": "^4.8.1",
-    "@typescript-eslint/parser": "^4.8.1",
-    "axe-core": "^4.0.2",
-    "cypress": "^10.1.0",
-    "eslint": "^7.12.0",
-    "eslint-config-tamia": "^7.2.6",
-    "http-server": "^0.12.3",
-    "husky": "^4.3.0",
-    "lint-staged": "^10.5.0",
-    "prettier": "^2.1.2",
-    "start-server-and-test": "^1.11.5",
-    "typescript": "^4.0.5"
-  },
-  "authors": [
-    {
-      "name": "Andy Van Slaars",
-      "url": "https://vanslaars.io"
-    },
-    {
-      "name": "Artem Sapegin",
-      "url": "https://sapegin.me"
-    }
-  ],
-  "keywords": [
-    "a11y",
-    "accessibility",
-    "axe",
-    "axe-core",
-    "cypress"
-  ],
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.js": "eslint --cache --fix",
-    "*.{js,md}": "prettier --write"
-  }
+	"name": "cypress-axe",
+	"version": "1.0.1-rc",
+	"license": "MIT",
+	"description": "Test accessibility with axe-core in Cypress",
+	"homepage": "https://github.com/component-driven/cypress-axe",
+	"repository": "component-driven/cypress-axe",
+	"files": [
+		"dist"
+	],
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsc",
+		"lint": "eslint . --cache --fix",
+		"pretest": "npm run lint",
+		"test": "npm run test:e2e:ci",
+		"posttest": "npm run format",
+		"format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
+		"prepublishOnly": "npm run build",
+		"start": "http-server test",
+		"cypress": "cypress open",
+		"cypress:headless": "cypress run --browser chrome --headless",
+		"test:e2e": "start-server-and-test start 8080 cypress",
+		"test:e2e:ci": "start-server-and-test start 8080 cypress:headless"
+	},
+	"engines": {
+		"node": ">=10"
+	},
+	"dependencies": {},
+	"peerDependencies": {
+		"axe-core": "^3 || ^4",
+		"cypress": "^10"
+	},
+	"devDependencies": {
+		"@types/node": "^14.14.8",
+		"@typescript-eslint/eslint-plugin": "^4.8.1",
+		"@typescript-eslint/parser": "^4.8.1",
+		"axe-core": "^4.0.2",
+		"cypress": "^10.1.0",
+		"eslint": "^7.12.0",
+		"eslint-config-tamia": "^7.2.6",
+		"http-server": "^0.12.3",
+		"husky": "^4.3.0",
+		"lint-staged": "^10.5.0",
+		"prettier": "^2.1.2",
+		"start-server-and-test": "^1.11.5",
+		"typescript": "^4.0.5"
+	},
+	"authors": [
+		{
+			"name": "Andy Van Slaars",
+			"url": "https://vanslaars.io"
+		},
+		{
+			"name": "Artem Sapegin",
+			"url": "https://sapegin.me"
+		}
+	],
+	"keywords": [
+		"a11y",
+		"accessibility",
+		"axe",
+		"axe-core",
+		"cypress"
+	],
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	},
+	"lint-staged": {
+		"*.js": "eslint --cache --fix",
+		"*.{js,md}": "prettier --write"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,76 +1,76 @@
 {
-	"name": "cypress-axe",
-	"version": "1.0.1-rc",
-	"license": "MIT",
-	"description": "Test accessibility with axe-core in Cypress",
-	"homepage": "https://github.com/component-driven/cypress-axe",
-	"repository": "component-driven/cypress-axe",
-	"files": [
-		"dist"
-	],
-	"main": "dist/index.js",
-	"types": "dist/index.d.ts",
-	"scripts": {
-		"build": "tsc",
-		"lint": "eslint . --cache --fix",
-		"pretest": "npm run lint",
-		"test": "npm run test:e2e:ci",
-		"posttest": "npm run format",
-		"format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
-		"prepublishOnly": "npm run build",
-		"start": "http-server test",
-		"cypress": "cypress open",
-		"cypress:headless": "cypress run --browser chrome --headless",
-		"test:e2e": "start-server-and-test start 8080 cypress",
-		"test:e2e:ci": "start-server-and-test start 8080 cypress:headless"
-	},
-	"engines": {
-		"node": ">=10"
-	},
-	"dependencies": {},
-	"peerDependencies": {
-		"axe-core": "^3 || ^4",
-		"cypress": "^10"
-	},
-	"devDependencies": {
-		"@types/node": "^14.14.8",
-		"@typescript-eslint/eslint-plugin": "^4.8.1",
-		"@typescript-eslint/parser": "^4.8.1",
-		"axe-core": "^4.0.2",
-		"cypress": "^10.1.0",
-		"eslint": "^7.12.0",
-		"eslint-config-tamia": "^7.2.6",
-		"http-server": "^0.12.3",
-		"husky": "^4.3.0",
-		"lint-staged": "^10.5.0",
-		"prettier": "^2.1.2",
-		"start-server-and-test": "^1.11.5",
-		"typescript": "^4.0.5"
-	},
-	"authors": [
-		{
-			"name": "Andy Van Slaars",
-			"url": "https://vanslaars.io"
-		},
-		{
-			"name": "Artem Sapegin",
-			"url": "https://sapegin.me"
-		}
-	],
-	"keywords": [
-		"a11y",
-		"accessibility",
-		"axe",
-		"axe-core",
-		"cypress"
-	],
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"lint-staged": {
-		"*.js": "eslint --cache --fix",
-		"*.{js,md}": "prettier --write"
-	}
+  "name": "cypress-axe",
+  "version": "0.8.1",
+  "license": "MIT",
+  "description": "Test accessibility with axe-core in Cypress",
+  "homepage": "https://github.com/component-driven/cypress-axe",
+  "repository": "component-driven/cypress-axe",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint . --cache --fix",
+    "pretest": "npm run lint",
+    "test": "npm run test:e2e:ci",
+    "posttest": "npm run format",
+    "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
+    "prepublishOnly": "npm run build",
+    "start": "http-server test",
+    "cypress": "cypress open",
+    "cypress:headless": "cypress run --browser chrome --headless",
+    "test:e2e": "start-server-and-test start 8080 cypress",
+    "test:e2e:ci": "start-server-and-test start 8080 cypress:headless"
+  },
+  "engines": {
+    "node": ">=10"
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "axe-core": "^3 || ^4",
+    "cypress": "^10" 
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.8",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
+    "@typescript-eslint/parser": "^4.8.1",
+    "axe-core": "^4.0.2",
+    "cypress": "^10.1.0",
+    "eslint": "^7.12.0",
+    "eslint-config-tamia": "^7.2.6",
+    "http-server": "^0.12.3",
+    "husky": "^4.3.0",
+    "lint-staged": "^10.5.0",
+    "prettier": "^2.1.2",
+    "start-server-and-test": "^1.11.5",
+    "typescript": "^4.0.5"
+  },
+  "authors": [
+    {
+      "name": "Andy Van Slaars",
+      "url": "https://vanslaars.io"
+    },
+    {
+      "name": "Artem Sapegin",
+      "url": "https://sapegin.me"
+    }
+  ],
+  "keywords": [
+    "a11y",
+    "accessibility",
+    "axe",
+    "axe-core",
+    "cypress"
+  ],
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": "eslint --cache --fix",
+    "*.{js,md}": "prettier --write"
+  }
 }


### PR DESCRIPTION
I found that the `includedImpacts` option was very helpful, but got me into a weird state in which I could have failures but not have the assertions logged out.

Here I've put together a rough and ready implementation of failure levels, meaning you can choose which levels of error you think are important enough to fail on per test. The way I've been using it is:

```js
    it('Fails only if the accessibility error is of serious or critical level', () => {
      const failOn = ['serious', 'critical'];
      cy.visit('/home');
      cy.injectAxe();
      cy.checkA11y(null, null, a11yLogFunction, failOn);
    });
```