### PR TITLE
fix: allow cypress-axe to be used when csp is set to deny eval()

### DIFF
--- a/cypress/e2e/test.cy.js
+++ b/cypress/e2e/test.cy.js
@@ -1,5 +1,5 @@
 it('works!', () => {
 	cy.visit('/');
 	cy.injectAxe();
-	cy.checkA11y();
+	cy.checkA11y('body');
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as axe from 'axe-core';
+import axe from 'axe-core';
 
 declare global {
 	interface Window {
@@ -22,15 +22,9 @@ export interface Options extends axe.RunOptions {
 }
 
 export const injectAxe = () => {
-	const fileName =
-		typeof require?.resolve === 'function'
-			? require.resolve('axe-core/axe.min.js')
-			: 'node_modules/axe-core/axe.min.js';
-	cy.readFile<string>(fileName).then((source) =>
-		cy.window({ log: false }).then((window) => {
-			window.eval(source);
-		})
-	);
+	cy.window({ log: false }).then((window) => {
+		window.axe = axe;
+	})
 };
 
 export const configureAxe = (configurationOptions = {}) => {


### PR DESCRIPTION
When `'unsafe-eval'` is used on a web page, cypress-axe can't run because the `injectAxe()` function calls `window.eval()`. 

From [the Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval):

> Warning: Executing JavaScript from a string is an enormous security risk. It is far too easy for a bad actor to run arbitrary code when you use eval(). See Never use eval()!, below. 

This commit updates the `injectAxe()` function to remove `eval` so that users of `unsafe-eval` can still use cypress-axe without having to override the `injectAxe()` function.