### PR TITLE
chore: updated peer dependency including Cypress 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         cypress-version: [10, 11, 12]
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
-        cypress-version: [10, 11]
+        node-version: [14.x, 16.x]
+        cypress-version: [10, 11, 12]
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-axe",
-  "version": "0.8.1",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-axe",
-      "version": "0.8.1",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.14.8",
@@ -28,7 +28,7 @@
       },
       "peerDependencies": {
         "axe-core": "^3 || ^4",
-        "cypress": "^10 || ^11"
+        "cypress": "^10 || ^11 || ^12"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {},
   "peerDependencies": {
     "axe-core": "^3 || ^4",
-    "cypress": "^10 || ^11"
+    "cypress": "^10 || ^11 || ^12"
   },
   "devDependencies": {
     "@types/node": "^14.14.8",
@@ -73,4 +73,4 @@
     "*.js": "eslint --cache --fix",
     "*.{js,md}": "prettier --write"
   }
-} 
+}


### PR DESCRIPTION
Related to #143 and #141.

Added peer dependencies to include Cypress 12.

Cypress 12 is dropping support for Node 12 (as it reached end of life) and added Node 18 (see [more details](https://docs.cypress.io/guides/references/changelog#12-0-1)).