### PR TITLE
Solving : Fix required not defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,10 @@ export interface InjectOptions {
 }
 
 export const injectAxe = (injectOptions?: InjectOptions) => {
+
 	const fileName =
 		injectOptions?.axeCorePath ||
-		(typeof require?.resolve === 'function'
+		(typeof require != 'undefined' && typeof require?.resolve === 'function'
 			? require.resolve('axe-core/axe.min.js')
 			: 'node_modules/axe-core/axe.min.js');
 	cy.readFile<string>(fileName).then((source) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export const injectAxe = (injectOptions?: InjectOptions) => {
 
 	const fileName =
 		injectOptions?.axeCorePath ||
-		(typeof require != 'undefined' && typeof require?.resolve === 'function'
+		(typeof require !== 'undefined' && typeof require?.resolve === 'function'
 			? require.resolve('axe-core/axe.min.js')
 			: 'node_modules/axe-core/axe.min.js');
 	cy.readFile<string>(fileName).then((source) =>


### PR DESCRIPTION
Hi, This patch aim to solve https://github.com/component-driven/cypress-axe/issues/170

the actual code rely on `required` be defined in the browser but this is not the case in my tests on Chrome browser:

Actual code
```
(typeof require?.resolve === 'function'
			? require.resolve('axe-core/axe.min.js')
			: 'node_modules/axe-core/axe.min.js');
```

console log

```
VM87:1 Uncaught ReferenceError: require is not defined
    at <anonymous>:1:1
(anonymous) @ VM87:1
```

Screenshot on Chrome
![error](https://github.com/component-driven/cypress-axe/assets/1525362/931a7880-5eff-4250-b8ea-71c28b10f82a)

Patch proposed : 

```
(typeof require != 'undefined' && typeof require?.resolve === 'function'
			? require.resolve('axe-core/axe.min.js')
			: 'node_modules/axe-core/axe.min.js');
```

**console log**

```
'node_modules/axe-core/axe.min.js'
```
![after patch](https://github.com/component-driven/cypress-axe/assets/1525362/33d72de8-12af-4291-a506-a32b9eb44fc4)

tagging last active developers @MehmetYararVX @johnhwhite for a review on this if possible 




