### PR TITLE
feat: add Cypress 14 as a peer dependency

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [lts/-2, lts/-1]
-        cypress-version: [10, 11, 12, 13]
+        cypress-version: [10, 11, 12, 13, 14]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {},
   "peerDependencies": {
     "axe-core": "^3 || ^4",
-    "cypress": "^10 || ^11 || ^12 || ^13"
+    "cypress": "^10 || ^11 || ^12 || ^13 || ^14"
   },
   "devDependencies": {
     "@types/node": "^14.14.8",


### PR DESCRIPTION
Cypress 14 released this afternoon. This PR adds Cypress 14 as a supported peer dependency of `cypress-axe`

closes #182